### PR TITLE
Auto-updating Spryker modules on 2023-12-05 16:15

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -16499,20 +16499,20 @@
         },
         {
             "name": "spryker/catalog",
-            "version": "5.9.0",
+            "version": "5.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/catalog.git",
-                "reference": "066e7fed831fc69e7285a44269ea44d5bb489ba4"
+                "reference": "b358c8f367c0b240a67cfd92788f0e120522bee5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/catalog/zipball/066e7fed831fc69e7285a44269ea44d5bb489ba4",
-                "reference": "066e7fed831fc69e7285a44269ea44d5bb489ba4",
+                "url": "https://api.github.com/repos/spryker/catalog/zipball/b358c8f367c0b240a67cfd92788f0e120522bee5",
+                "reference": "b358c8f367c0b240a67cfd92788f0e120522bee5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/catalog-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/search": "^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -16548,9 +16548,9 @@
             ],
             "description": "Catalog module",
             "support": {
-                "source": "https://github.com/spryker/catalog/tree/5.9.0"
+                "source": "https://github.com/spryker/catalog/tree/5.10.0"
             },
-            "time": "2023-09-11T11:36:57+00:00"
+            "time": "2023-11-17T13:33:28+00:00"
         },
         {
             "name": "spryker/catalog-extension",

--- a/composer.lock
+++ b/composer.lock
@@ -28042,20 +28042,20 @@
         },
         {
             "name": "spryker/message-broker",
-            "version": "1.9.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/message-broker.git",
-                "reference": "39bca2ed0ad89f3168b667188a2b79e5e4bcadc8"
+                "reference": "9c58d443d093094c8200f5bfe13bf89b39a69d2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/message-broker/zipball/39bca2ed0ad89f3168b667188a2b79e5e4bcadc8",
-                "reference": "39bca2ed0ad89f3168b667188a2b79e5e4bcadc8",
+                "url": "https://api.github.com/repos/spryker/message-broker/zipball/9c58d443d093094c8200f5bfe13bf89b39a69d2d",
+                "reference": "9c58d443d093094c8200f5bfe13bf89b39a69d2d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/kernel": "^3.30.0",
                 "spryker/log": "^3.0.0",
                 "spryker/message-broker-extension": "^1.2.0",
@@ -28097,9 +28097,9 @@
             ],
             "description": "MessageBroker module",
             "support": {
-                "source": "https://github.com/spryker/message-broker/tree/1.9.0"
+                "source": "https://github.com/spryker/message-broker/tree/1.9.1"
             },
-            "time": "2023-08-31T11:27:42+00:00"
+            "time": "2023-11-22T15:24:58+00:00"
         },
         {
             "name": "spryker/message-broker-aws",
@@ -46086,20 +46086,20 @@
         },
         {
             "name": "spryker/tax-app",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/tax-app.git",
-                "reference": "a6b7a4375f28cb65ffd99e69e1835654c52646d9"
+                "reference": "c97d55ec05dfe85aa3e94403ede60cc44d32ba6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/tax-app/zipball/a6b7a4375f28cb65ffd99e69e1835654c52646d9",
-                "reference": "a6b7a4375f28cb65ffd99e69e1835654c52646d9",
+                "url": "https://api.github.com/repos/spryker/tax-app/zipball/c97d55ec05dfe85aa3e94403ede60cc44d32ba6e",
+                "reference": "c97d55ec05dfe85aa3e94403ede60cc44d32ba6e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "psr/http-message": "^1.0.0",
                 "spryker/calculation-extension": "^1.0.0",
                 "spryker/guzzle": "^2.4.1",
@@ -46151,9 +46151,9 @@
             ],
             "description": "TaxApp module",
             "support": {
-                "source": "https://github.com/spryker/tax-app/tree/0.2.0"
+                "source": "https://github.com/spryker/tax-app/tree/0.2.1"
             },
-            "time": "2023-10-26T12:55:48+00:00"
+            "time": "2023-11-22T15:24:58+00:00"
         },
         {
             "name": "spryker/tax-app-extension",

--- a/composer.lock
+++ b/composer.lock
@@ -9224,16 +9224,16 @@
         },
         {
             "name": "spryker-shop/customer-page",
-            "version": "2.47.0",
+            "version": "2.49.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/customer-page.git",
-                "reference": "fccadb383a9e85054e918f7d2a010f888710ed39"
+                "reference": "08ba64b07809edc26c5865c3289f50ccefeb744a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/customer-page/zipball/fccadb383a9e85054e918f7d2a010f888710ed39",
-                "reference": "fccadb383a9e85054e918f7d2a010f888710ed39",
+                "url": "https://api.github.com/repos/spryker-shop/customer-page/zipball/08ba64b07809edc26c5865c3289f50ccefeb744a",
+                "reference": "08ba64b07809edc26c5865c3289f50ccefeb744a",
                 "shasum": ""
             },
             "require": {
@@ -9250,11 +9250,13 @@
                 "spryker/quote": "^1.0.0 || ^2.1.0",
                 "spryker/router": "^1.6.0",
                 "spryker/sales": "^8.15.0 || ^10.0.0 || ^11.8.0",
+                "spryker/security-blocker": "^1.0.0",
                 "spryker/security-extension": "^1.0.0",
                 "spryker/shipment": "^7.0.0 || ^8.0.0",
                 "spryker/step-engine": "^3.3.0",
                 "spryker/store": "^1.19.0",
                 "spryker/symfony": "^3.1.0",
+                "spryker/transfer": "^3.25.0",
                 "spryker/twig": "^3.18.0",
                 "spryker/twig-extension": "^1.0.0",
                 "spryker/util-validate": "^1.0.0"
@@ -9315,9 +9317,9 @@
             ],
             "description": "CustomerPage module",
             "support": {
-                "source": "https://github.com/spryker-shop/customer-page/tree/2.47.0"
+                "source": "https://github.com/spryker-shop/customer-page/tree/2.49.0"
             },
-            "time": "2023-11-02T20:09:30+00:00"
+            "time": "2023-11-24T22:16:29+00:00"
         },
         {
             "name": "spryker-shop/customer-page-extension",
@@ -22734,16 +22736,16 @@
         },
         {
             "name": "spryker/customer",
-            "version": "7.52.0",
+            "version": "7.53.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/customer.git",
-                "reference": "1528274b54d1eb1bfbf0da8c29fae4da2f248696"
+                "reference": "3a201143cb7b4033f11a2050120d4bd744c160eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/customer/zipball/1528274b54d1eb1bfbf0da8c29fae4da2f248696",
-                "reference": "1528274b54d1eb1bfbf0da8c29fae4da2f248696",
+                "url": "https://api.github.com/repos/spryker/customer/zipball/3a201143cb7b4033f11a2050120d4bd744c160eb",
+                "reference": "3a201143cb7b4033f11a2050120d4bd744c160eb",
                 "shasum": ""
             },
             "require": {
@@ -22810,9 +22812,9 @@
             ],
             "description": "Customer module",
             "support": {
-                "source": "https://github.com/spryker/customer/tree/7.52.0"
+                "source": "https://github.com/spryker/customer/tree/7.53.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2023-11-24T22:16:26+00:00"
         },
         {
             "name": "spryker/customer-access",
@@ -42814,16 +42816,16 @@
         },
         {
             "name": "spryker/security-gui",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/security-gui.git",
-                "reference": "45c1be9a89726a82a71c31afd4a472fc21d2a190"
+                "reference": "6ed419c3267d56e6bc91abea2268926943c28719"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/security-gui/zipball/45c1be9a89726a82a71c31afd4a472fc21d2a190",
-                "reference": "45c1be9a89726a82a71c31afd4a472fc21d2a190",
+                "url": "https://api.github.com/repos/spryker/security-gui/zipball/6ed419c3267d56e6bc91abea2268926943c28719",
+                "reference": "6ed419c3267d56e6bc91abea2268926943c28719",
                 "shasum": ""
             },
             "require": {
@@ -42831,6 +42833,7 @@
                 "spryker/kernel": "^3.30.0",
                 "spryker/messenger": "^3.0.0",
                 "spryker/security": "^1.3.0",
+                "spryker/security-blocker": "^1.0.0",
                 "spryker/security-extension": "^1.0.0",
                 "spryker/security-gui-extension": "^1.2.0",
                 "spryker/symfony": "^3.5.0",
@@ -42872,9 +42875,9 @@
             ],
             "description": "SecurityGui module",
             "support": {
-                "source": "https://github.com/spryker/security-gui/tree/1.4.0"
+                "source": "https://github.com/spryker/security-gui/tree/1.5.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2023-11-24T22:16:26+00:00"
         },
         {
             "name": "spryker/security-gui-extension",
@@ -47205,22 +47208,23 @@
         },
         {
             "name": "spryker/user-password-reset",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/user-password-reset.git",
-                "reference": "c2cbea430658f1d4a0b4f110018e43d4cdcac450"
+                "reference": "9b8df93135a0f0c6b88f54c0681dbe0a78e51f7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/user-password-reset/zipball/c2cbea430658f1d4a0b4f110018e43d4cdcac450",
-                "reference": "c2cbea430658f1d4a0b4f110018e43d4cdcac450",
+                "url": "https://api.github.com/repos/spryker/user-password-reset/zipball/9b8df93135a0f0c6b88f54c0681dbe0a78e51f7c",
+                "reference": "9b8df93135a0f0c6b88f54c0681dbe0a78e51f7c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
+                "spryker/propel-orm": "^1.0.0",
                 "spryker/transfer": "^3.27.0",
                 "spryker/user": "^3.17.0",
                 "spryker/user-password-reset-extension": "^1.0.0",
@@ -47248,9 +47252,9 @@
             ],
             "description": "UserPasswordReset module",
             "support": {
-                "source": "https://github.com/spryker/user-password-reset/tree/1.4.0"
+                "source": "https://github.com/spryker/user-password-reset/tree/1.5.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-11-24T22:16:26+00:00"
         },
         {
             "name": "spryker/user-password-reset-extension",

--- a/composer.lock
+++ b/composer.lock
@@ -18938,16 +18938,16 @@
         },
         {
             "name": "spryker/cms-gui",
-            "version": "5.13.0",
+            "version": "5.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cms-gui.git",
-                "reference": "c67726a87afe274fecaa0e21ba953fa9633f20f9"
+                "reference": "635948a2626c42fe4910263903e9f8954570a30c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/cms-gui/zipball/c67726a87afe274fecaa0e21ba953fa9633f20f9",
-                "reference": "c67726a87afe274fecaa0e21ba953fa9633f20f9",
+                "url": "https://api.github.com/repos/spryker/cms-gui/zipball/635948a2626c42fe4910263903e9f8954570a30c",
+                "reference": "635948a2626c42fe4910263903e9f8954570a30c",
                 "shasum": ""
             },
             "require": {
@@ -18959,7 +18959,9 @@
                 "spryker/gui": "^3.48.0",
                 "spryker/kernel": "^3.52.0",
                 "spryker/locale": "^3.0.0 || ^4.0.0",
+                "spryker/propel-orm": "^1.0.0",
                 "spryker/symfony": "^3.0.0",
+                "spryker/transfer": "^3.25.0",
                 "spryker/twig": "^3.0.0",
                 "spryker/url": "^3.5.0",
                 "spryker/util-encoding": "^2.0.0",
@@ -18996,9 +18998,9 @@
             ],
             "description": "CmsGui module",
             "support": {
-                "source": "https://github.com/spryker/cms-gui/tree/5.13.0"
+                "source": "https://github.com/spryker/cms-gui/tree/5.14.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2023-11-15T11:17:28+00:00"
         },
         {
             "name": "spryker/cms-gui-extension",

--- a/composer.lock
+++ b/composer.lock
@@ -44461,16 +44461,16 @@
         },
         {
             "name": "spryker/state-machine",
-            "version": "2.19.0",
+            "version": "2.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/state-machine.git",
-                "reference": "f9305392e0336cfbbf6ba581a7a1ff649662e663"
+                "reference": "c14a7b53e43d223cbedd85ed2eed976041f93e28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/state-machine/zipball/f9305392e0336cfbbf6ba581a7a1ff649662e663",
-                "reference": "f9305392e0336cfbbf6ba581a7a1ff649662e663",
+                "url": "https://api.github.com/repos/spryker/state-machine/zipball/c14a7b53e43d223cbedd85ed2eed976041f93e28",
+                "reference": "c14a7b53e43d223cbedd85ed2eed976041f93e28",
                 "shasum": ""
             },
             "require": {
@@ -44482,6 +44482,7 @@
                 "spryker/symfony": "^3.0.0",
                 "spryker/transfer": "^3.25.0",
                 "spryker/util-network": "^1.1.0",
+                "spryker/util-sanitize-xss": "^1.1.0",
                 "spryker/util-text": "^1.1.0"
             },
             "require-dev": {
@@ -44508,9 +44509,9 @@
             ],
             "description": "StateMachine module",
             "support": {
-                "source": "https://github.com/spryker/state-machine/tree/2.19.0"
+                "source": "https://github.com/spryker/state-machine/tree/2.20.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2023-11-29T09:16:52+00:00"
         },
         {
             "name": "spryker/step-engine",

--- a/composer.lock
+++ b/composer.lock
@@ -8123,16 +8123,16 @@
         },
         {
             "name": "spryker-shop/checkout-page",
-            "version": "3.29.2",
+            "version": "3.29.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/checkout-page.git",
-                "reference": "1e4e57a6f9fa2bb7c92b3f590c43449dc7899524"
+                "reference": "f07b111a4c58a8d4e60ec2fc57faeb37c3d221ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/checkout-page/zipball/1e4e57a6f9fa2bb7c92b3f590c43449dc7899524",
-                "reference": "1e4e57a6f9fa2bb7c92b3f590c43449dc7899524",
+                "url": "https://api.github.com/repos/spryker-shop/checkout-page/zipball/f07b111a4c58a8d4e60ec2fc57faeb37c3d221ff",
+                "reference": "f07b111a4c58a8d4e60ec2fc57faeb37c3d221ff",
                 "shasum": ""
             },
             "require": {
@@ -8187,6 +8187,7 @@
                 "spryker-shop/order-custom-reference-widget": "Add the module if you want to use order custom reference functionality",
                 "spryker-shop/product-packaging-unit-widget": "If you want to use components from module ProductPackagingUnitWidget or SummaryProductPackagingUnitWidgetPlugin: ^0.5.2",
                 "spryker-shop/quote-request-widget": "If you want to use QuoteRequestActionsWidget: ^2.2.0",
+                "spryker-shop/service-point-widget": "Add the module if you want to use service point widget",
                 "spryker-shop/shipment-type-widget": "Add the module if you want to use ShipmentTypeAddressFormWidget.",
                 "spryker/router": "Use this module when you want to use the Router.",
                 "spryker/shipment-cart-connector": "If you want to use shipment totals in quote or shipment source prices, min version 2.1.0",
@@ -8209,9 +8210,9 @@
             ],
             "description": "CheckoutPage module",
             "support": {
-                "source": "https://github.com/spryker-shop/checkout-page/tree/3.29.2"
+                "source": "https://github.com/spryker-shop/checkout-page/tree/3.29.3"
             },
-            "time": "2023-11-17T11:19:58+00:00"
+            "time": "2023-11-21T09:36:32+00:00"
         },
         {
             "name": "spryker-shop/checkout-page-extension",

--- a/composer.lock
+++ b/composer.lock
@@ -8123,16 +8123,16 @@
         },
         {
             "name": "spryker-shop/checkout-page",
-            "version": "3.29.1",
+            "version": "3.29.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/checkout-page.git",
-                "reference": "ca6146dda8aba906f766c32fa76132dbf8315d1c"
+                "reference": "1e4e57a6f9fa2bb7c92b3f590c43449dc7899524"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/checkout-page/zipball/ca6146dda8aba906f766c32fa76132dbf8315d1c",
-                "reference": "ca6146dda8aba906f766c32fa76132dbf8315d1c",
+                "url": "https://api.github.com/repos/spryker-shop/checkout-page/zipball/1e4e57a6f9fa2bb7c92b3f590c43449dc7899524",
+                "reference": "1e4e57a6f9fa2bb7c92b3f590c43449dc7899524",
                 "shasum": ""
             },
             "require": {
@@ -8180,7 +8180,7 @@
                 "spryker-shop/cart-code-widget": "If you want to use components from module CartCodeWidget or CheckoutVoucherFormWidget or CheckoutVoucherFormWidgetPlugin",
                 "spryker-shop/cart-note-widget": "If you want to use components from module CartNoteWidget or CartNoteQuoteItemNoteWidgetPlugin.",
                 "spryker-shop/checkout-widget": "Add the module if you want to use checkout widget",
-                "spryker-shop/company-widget": "Add the module if you want to use company widget, use the version >= 1.8.0",
+                "spryker-shop/company-widget": "Add the module if you want to use company widget, use the version >= 1.9.0",
                 "spryker-shop/configurable-bundle-widget": "Add the module if you want to use QuoteConfiguredBundleWidget.",
                 "spryker-shop/gift-card-widget": "Add the module if you want to use gift card widget",
                 "spryker-shop/merchant-widget": "If you want to use MerchantMetaSchemaWidget use the version >= 1.3.0",
@@ -8209,9 +8209,9 @@
             ],
             "description": "CheckoutPage module",
             "support": {
-                "source": "https://github.com/spryker-shop/checkout-page/tree/3.29.1"
+                "source": "https://github.com/spryker-shop/checkout-page/tree/3.29.2"
             },
-            "time": "2023-11-08T09:58:38+00:00"
+            "time": "2023-11-17T11:19:58+00:00"
         },
         {
             "name": "spryker-shop/checkout-page-extension",

--- a/composer.lock
+++ b/composer.lock
@@ -39967,16 +39967,16 @@
         },
         {
             "name": "spryker/sales",
-            "version": "11.42.0",
+            "version": "11.42.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/sales.git",
-                "reference": "7600f8d0c08e79b97e10f1173d5c4065eadaeab4"
+                "reference": "ed40dae4b55ef82130bfee8dd9870c9bea30ebce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/sales/zipball/7600f8d0c08e79b97e10f1173d5c4065eadaeab4",
-                "reference": "7600f8d0c08e79b97e10f1173d5c4065eadaeab4",
+                "url": "https://api.github.com/repos/spryker/sales/zipball/ed40dae4b55ef82130bfee8dd9870c9bea30ebce",
+                "reference": "ed40dae4b55ef82130bfee8dd9870c9bea30ebce",
                 "shasum": ""
             },
             "require": {
@@ -40042,9 +40042,9 @@
             ],
             "description": "Sales module",
             "support": {
-                "source": "https://github.com/spryker/sales/tree/11.42.0"
+                "source": "https://github.com/spryker/sales/tree/11.42.1"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2023-11-22T10:16:20+00:00"
         },
         {
             "name": "spryker/sales-configurable-bundle",
@@ -40516,20 +40516,20 @@
         },
         {
             "name": "spryker/sales-order-threshold-gui",
-            "version": "1.9.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/sales-order-threshold-gui.git",
-                "reference": "290e985b8b8061df305f00ab712a54ee3f6b8081"
+                "reference": "70682e3bed43716b06aa2d2ba3b393e5ad1d845b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/sales-order-threshold-gui/zipball/290e985b8b8061df305f00ab712a54ee3f6b8081",
-                "reference": "290e985b8b8061df305f00ab712a54ee3f6b8081",
+                "url": "https://api.github.com/repos/spryker/sales-order-threshold-gui/zipball/70682e3bed43716b06aa2d2ba3b393e5ad1d845b",
+                "reference": "70682e3bed43716b06aa2d2ba3b393e5ad1d845b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/currency": "^3.1.0 || ^4.0.0",
                 "spryker/gui": "^3.45.0",
                 "spryker/kernel": "^3.30.0",
@@ -40561,9 +40561,9 @@
             ],
             "description": "SalesOrderThresholdGui module",
             "support": {
-                "source": "https://github.com/spryker/sales-order-threshold-gui/tree/1.9.0"
+                "source": "https://github.com/spryker/sales-order-threshold-gui/tree/1.9.1"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-22T10:16:20+00:00"
         },
         {
             "name": "spryker/sales-order-threshold-gui-extension",
@@ -43923,16 +43923,16 @@
         },
         {
             "name": "spryker/shipment-gui",
-            "version": "2.10.0",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/shipment-gui.git",
-                "reference": "864880cac1da6ee2f1064686232887beb3eeb0a7"
+                "reference": "bae94e2210b184e380401edce981684203897d57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/shipment-gui/zipball/864880cac1da6ee2f1064686232887beb3eeb0a7",
-                "reference": "864880cac1da6ee2f1064686232887beb3eeb0a7",
+                "url": "https://api.github.com/repos/spryker/shipment-gui/zipball/bae94e2210b184e380401edce981684203897d57",
+                "reference": "bae94e2210b184e380401edce981684203897d57",
                 "shasum": ""
             },
             "require": {
@@ -43985,9 +43985,9 @@
             ],
             "description": "ShipmentGui module",
             "support": {
-                "source": "https://github.com/spryker/shipment-gui/tree/2.10.0"
+                "source": "https://github.com/spryker/shipment-gui/tree/2.10.1"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2023-11-22T10:16:20+00:00"
         },
         {
             "name": "spryker/shipment-gui-extension",

--- a/composer.lock
+++ b/composer.lock
@@ -40758,20 +40758,20 @@
         },
         {
             "name": "spryker/sales-payment",
-            "version": "1.3.2",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/sales-payment.git",
-                "reference": "ed394c4003cca367489c4520f329746fc0a453a1"
+                "reference": "11834ceeec28ecbb30956b0605e5a67478fe7850"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/sales-payment/zipball/ed394c4003cca367489c4520f329746fc0a453a1",
-                "reference": "ed394c4003cca367489c4520f329746fc0a453a1",
+                "url": "https://api.github.com/repos/spryker/sales-payment/zipball/11834ceeec28ecbb30956b0605e5a67478fe7850",
+                "reference": "11834ceeec28ecbb30956b0605e5a67478fe7850",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/checkout-extension": "^1.2.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/message-broker": "^1.2.0",
@@ -40812,9 +40812,9 @@
             ],
             "description": "SalesPayment module",
             "support": {
-                "source": "https://github.com/spryker/sales-payment/tree/1.3.2"
+                "source": "https://github.com/spryker/sales-payment/tree/1.4.0"
             },
-            "time": "2023-06-16T09:24:47+00:00"
+            "time": "2023-11-22T13:54:23+00:00"
         },
         {
             "name": "spryker/sales-payment-extension",

--- a/composer.lock
+++ b/composer.lock
@@ -46466,16 +46466,16 @@
         },
         {
             "name": "spryker/transfer",
-            "version": "3.34.0",
+            "version": "3.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/transfer.git",
-                "reference": "dfabe1a4dc33b713cf2487cf42f95d6d2f8d525b"
+                "reference": "539b53f9da85ccdfeb17f64c18c0c2ba3eac2e79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/transfer/zipball/dfabe1a4dc33b713cf2487cf42f95d6d2f8d525b",
-                "reference": "dfabe1a4dc33b713cf2487cf42f95d6d2f8d525b",
+                "url": "https://api.github.com/repos/spryker/transfer/zipball/539b53f9da85ccdfeb17f64c18c0c2ba3eac2e79",
+                "reference": "539b53f9da85ccdfeb17f64c18c0c2ba3eac2e79",
                 "shasum": ""
             },
             "require": {
@@ -46511,9 +46511,9 @@
             ],
             "description": "Transfer module",
             "support": {
-                "source": "https://github.com/spryker/transfer/tree/3.34.0"
+                "source": "https://github.com/spryker/transfer/tree/3.35.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2023-11-20T09:35:42+00:00"
         },
         {
             "name": "spryker/translator",

--- a/composer.lock
+++ b/composer.lock
@@ -34132,20 +34132,20 @@
         },
         {
             "name": "spryker/product-configuration-wishlists-rest-api",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-configuration-wishlists-rest-api.git",
-                "reference": "bff3dc43ef050889feefeac1f2cf0c49c631eed2"
+                "reference": "4aeeba6e5cd19262ea7bafdd3a6f602e5e9dfeba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-configuration-wishlists-rest-api/zipball/bff3dc43ef050889feefeac1f2cf0c49c631eed2",
-                "reference": "bff3dc43ef050889feefeac1f2cf0c49c631eed2",
+                "url": "https://api.github.com/repos/spryker/product-configuration-wishlists-rest-api/zipball/4aeeba6e5cd19262ea7bafdd3a6f602e5e9dfeba",
+                "reference": "4aeeba6e5cd19262ea7bafdd3a6f602e5e9dfeba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/kernel": "^3.30.0",
                 "spryker/product-configuration": "^1.0.0",
                 "spryker/product-configuration-wishlists-rest-api-extension": "^1.0.0",
@@ -34180,9 +34180,9 @@
             ],
             "description": "ProductConfigurationWishlistsRestApi module",
             "support": {
-                "source": "https://github.com/spryker/product-configuration-wishlists-rest-api/tree/1.1.3"
+                "source": "https://github.com/spryker/product-configuration-wishlists-rest-api/tree/1.1.4"
             },
-            "time": "2023-05-05T18:20:59+00:00"
+            "time": "2023-11-17T13:40:35+00:00"
         },
         {
             "name": "spryker/product-configuration-wishlists-rest-api-extension",
@@ -34276,20 +34276,20 @@
         },
         {
             "name": "spryker/product-configurations-rest-api",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-configurations-rest-api.git",
-                "reference": "238c2cc872406b93c147ce6d5ccf81178b0dbaa2"
+                "reference": "3be9bbc3926f868d559b0cb993c1e692d305595c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-configurations-rest-api/zipball/238c2cc872406b93c147ce6d5ccf81178b0dbaa2",
-                "reference": "238c2cc872406b93c147ce6d5ccf81178b0dbaa2",
+                "url": "https://api.github.com/repos/spryker/product-configurations-rest-api/zipball/3be9bbc3926f868d559b0cb993c1e692d305595c",
+                "reference": "3be9bbc3926f868d559b0cb993c1e692d305595c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/carts-rest-api-extension": "^1.5.0",
                 "spryker/glue-application": "^1.6.0",
                 "spryker/glue-application-extension": "^1.1.0",
@@ -34326,9 +34326,9 @@
             ],
             "description": "ProductConfigurationsRestApi module",
             "support": {
-                "source": "https://github.com/spryker/product-configurations-rest-api/tree/1.0.3"
+                "source": "https://github.com/spryker/product-configurations-rest-api/tree/1.0.4"
             },
-            "time": "2023-05-05T18:20:59+00:00"
+            "time": "2023-11-17T13:40:35+00:00"
         },
         {
             "name": "spryker/product-configurations-rest-api-extension",

--- a/composer.lock
+++ b/composer.lock
@@ -23649,26 +23649,27 @@
         },
         {
             "name": "spryker/data-export",
-            "version": "0.1.3",
+            "version": "0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/data-export.git",
-                "reference": "2f398fbe1a2023283cceef3dd9c1b0aaf7e5b5bc"
+                "reference": "79a3ca33d5abd0e2737e39e3529c3183d93b0d11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/data-export/zipball/2f398fbe1a2023283cceef3dd9c1b0aaf7e5b5bc",
-                "reference": "2f398fbe1a2023283cceef3dd9c1b0aaf7e5b5bc",
+                "url": "https://api.github.com/repos/spryker/data-export/zipball/79a3ca33d5abd0e2737e39e3529c3183d93b0d11",
+                "reference": "79a3ca33d5abd0e2737e39e3529c3183d93b0d11",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
+                "php": ">=8.1",
                 "spryker/csv": "^3.0.0",
                 "spryker/data-export-extension": "^0.1.0",
                 "spryker/graceful-runner": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
+                "spryker/log": "^3.0.0",
                 "spryker/symfony": "^3.0.0",
-                "spryker/transfer": "^3.8.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/util-data-reader": "^1.1.0"
             },
             "require-dev": {
@@ -23692,9 +23693,9 @@
             ],
             "description": "DataExport module",
             "support": {
-                "source": "https://github.com/spryker/data-export/tree/0.1.3"
+                "source": "https://github.com/spryker/data-export/tree/0.1.4"
             },
-            "time": "2021-02-17T09:10:22+00:00"
+            "time": "2023-11-23T15:03:23+00:00"
         },
         {
             "name": "spryker/data-export-extension",
@@ -31768,16 +31769,16 @@
         },
         {
             "name": "spryker/price-product-schedule-gui",
-            "version": "2.7.0",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/price-product-schedule-gui.git",
-                "reference": "4b76618e538d3539283b0b6d99ec76da51de866e"
+                "reference": "c367b5fc3fb619b3ee688d2e208616ae110d2c54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/price-product-schedule-gui/zipball/4b76618e538d3539283b0b6d99ec76da51de866e",
-                "reference": "4b76618e538d3539283b0b6d99ec76da51de866e",
+                "url": "https://api.github.com/repos/spryker/price-product-schedule-gui/zipball/c367b5fc3fb619b3ee688d2e208616ae110d2c54",
+                "reference": "c367b5fc3fb619b3ee688d2e208616ae110d2c54",
                 "shasum": ""
             },
             "require": {
@@ -31794,9 +31795,10 @@
                 "spryker/propel-orm": "^1.8.0",
                 "spryker/store": "^1.10.0",
                 "spryker/symfony": "^3.2.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/translator": "^1.1.0",
                 "spryker/twig": "^3.16.0",
-                "spryker/util-csv": "^1.0.0",
+                "spryker/util-csv": "^1.1.0",
                 "spryker/util-date-time": "^1.4.0",
                 "spryker/util-text": "^1.2.0",
                 "spryker/validator": "^1.2.0"
@@ -31824,9 +31826,9 @@
             ],
             "description": "PriceProductScheduleGui module",
             "support": {
-                "source": "https://github.com/spryker/price-product-schedule-gui/tree/2.7.0"
+                "source": "https://github.com/spryker/price-product-schedule-gui/tree/2.8.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2023-11-23T15:03:23+00:00"
         },
         {
             "name": "spryker/price-product-storage",
@@ -35855,16 +35857,16 @@
         },
         {
             "name": "spryker/product-list-gui",
-            "version": "2.5.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-list-gui.git",
-                "reference": "e5704b595fff96ff623b2b1bb62d14a8b2cd91a4"
+                "reference": "b8d8d108007f2c264006825a184048a3988dd998"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-list-gui/zipball/e5704b595fff96ff623b2b1bb62d14a8b2cd91a4",
-                "reference": "e5704b595fff96ff623b2b1bb62d14a8b2cd91a4",
+                "url": "https://api.github.com/repos/spryker/product-list-gui/zipball/b8d8d108007f2c264006825a184048a3988dd998",
+                "reference": "b8d8d108007f2c264006825a184048a3988dd998",
                 "shasum": ""
             },
             "require": {
@@ -35879,7 +35881,8 @@
                 "spryker/product-list-gui-extension": "^1.2.0",
                 "spryker/propel-orm": "^1.0.0",
                 "spryker/symfony": "^3.0.0",
-                "spryker/util-csv": "^1.0.0",
+                "spryker/transfer": "^3.27.0",
+                "spryker/util-csv": "^1.1.0",
                 "spryker/util-text": "^1.1.0",
                 "spryker/validator": "^1.2.0"
             },
@@ -35906,9 +35909,9 @@
             ],
             "description": "ProductListGui module",
             "support": {
-                "source": "https://github.com/spryker/product-list-gui/tree/2.5.0"
+                "source": "https://github.com/spryker/product-list-gui/tree/2.6.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2023-11-23T15:03:23+00:00"
         },
         {
             "name": "spryker/product-list-gui-extension",
@@ -47402,22 +47405,23 @@
         },
         {
             "name": "spryker/util-csv",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/util-csv.git",
-                "reference": "b90e0453dd6555297eebba14923e0ee21d90d6f3"
+                "reference": "a5daf36cab0e78ac3ed806900925cea7c32dbab7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/util-csv/zipball/b90e0453dd6555297eebba14923e0ee21d90d6f3",
-                "reference": "b90e0453dd6555297eebba14923e0ee21d90d6f3",
+                "url": "https://api.github.com/repos/spryker/util-csv/zipball/a5daf36cab0e78ac3ed806900925cea7c32dbab7",
+                "reference": "a5daf36cab0e78ac3ed806900925cea7c32dbab7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1",
-                "spryker/kernel": "^3.0.0",
-                "spryker/symfony": "^3.1.0"
+                "php": ">=8.1",
+                "spryker/kernel": "^3.30.0",
+                "spryker/symfony": "^3.1.0",
+                "spryker/transfer": "^3.27.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
@@ -47440,9 +47444,9 @@
             ],
             "description": "UtilCsv module",
             "support": {
-                "source": "https://github.com/spryker/util-csv/tree/master"
+                "source": "https://github.com/spryker/util-csv/tree/1.1.0"
             },
-            "time": "2018-07-10T12:34:02+00:00"
+            "time": "2023-11-23T15:03:23+00:00"
         },
         {
             "name": "spryker/util-data-reader",

--- a/config/Shared/config_default.php
+++ b/config/Shared/config_default.php
@@ -656,6 +656,7 @@ $config[OmsConstants::PROCESS_LOCATION] = [
 ];
 $config[OmsConstants::ACTIVE_PROCESSES] = [
     'ForeignPaymentB2CStateMachine01',
+    'ForeignPaymentStateMachine01',
 ];
 $config[SalesConstants::PAYMENT_METHOD_STATEMACHINE_MAPPING] = [
     PaymentConfig::PAYMENT_FOREIGN_PROVIDER => 'ForeignPaymentB2CStateMachine01',

--- a/src/Pyz/Yves/CustomerPage/CustomerPageConfig.php
+++ b/src/Pyz/Yves/CustomerPage/CustomerPageConfig.php
@@ -12,6 +12,11 @@ use SprykerShop\Yves\CustomerPage\CustomerPageConfig as SprykerCustomerPageConfi
 class CustomerPageConfig extends SprykerCustomerPageConfig
 {
     /**
+     * @var bool
+     */
+    protected const CUSTOMER_SECURITY_BLOCKER_ENABLED = true;
+
+    /**
      * @var string
      */
     protected const LOGIN_FAILURE_REDIRECT_URL = '/login';

--- a/src/Pyz/Zed/Customer/CustomerConfig.php
+++ b/src/Pyz/Zed/Customer/CustomerConfig.php
@@ -12,6 +12,11 @@ use Spryker\Zed\Customer\CustomerConfig as SprykerCustomerConfig;
 class CustomerConfig extends SprykerCustomerConfig
 {
     /**
+     * @var bool
+     */
+    protected const PASSWORD_RESET_EXPIRATION_IS_ENABLED = true;
+
+    /**
      * @var int
      */
     protected const MIN_LENGTH_CUSTOMER_PASSWORD = 8;

--- a/src/Pyz/Zed/SecurityGui/SecurityGuiConfig.php
+++ b/src/Pyz/Zed/SecurityGui/SecurityGuiConfig.php
@@ -12,6 +12,11 @@ use Spryker\Zed\SecurityGui\SecurityGuiConfig as SprykerSecurityGuiConfig;
 class SecurityGuiConfig extends SprykerSecurityGuiConfig
 {
     /**
+     * @var bool
+     */
+    protected const IS_BACKOFFICE_USER_SECURITY_BLOCKER_ENABLED = true;
+
+    /**
      * @var string
      */
     protected const IGNORABLE_ROUTE_PATTERN = '^/(security-gui|health-check|_profiler/wdt|api/rest/.+)';


### PR DESCRIPTION
Upgrader installed 12 release group(s) (including 2 security fix(es)) containing 22 package version(s).
| Release | Efforts saved by Upgrader | Warnings detected? | These new modules might be interesting for you |
| ------- | ---- | ------------------ | ------------------ |
| [Fixed Insecure Password Reset Workflow](https://api.release.spryker.com/release-group/5137) |89% |No |[spryker/security-merchant-portal-gui:2.2.0](https://github.com/spryker/security-merchant-portal-gui) |
| [Improved controllers input validation.](https://api.release.spryker.com/release-group/5152) |100% |No | |
| [Fixed CMS page table localisations in the Backoffi...](https://api.release.spryker.com/release-group/5115) |100% |No | |
| [Fixed multiple addresses state on Checkout.](https://api.release.spryker.com/release-group/5113) |100% |No |[spryker-shop/shop.company-widget:1.9.0](https://github.com/spryker-shop/shop.company-widget) |
| [Configurable Bundles. Not all products are display...](https://api.release.spryker.com/release-group/5120) |100% |No | |
| [Updated product configuration API validation.](https://api.release.spryker.com/release-group/5126) |100% |No |[spryker/product-configuration-shopping-lists-rest-api:1.0.3](https://github.com/spryker/product-configuration-shopping-lists-rest-api) |
| [Fixed docblocks from deprecated to generic syntax](https://api.release.spryker.com/release-group/5033) |0% |No | |
| [Yves: Service Point name is not shown for all orde...](https://api.release.spryker.com/release-group/5127) |100% |No |[spryker-shop/shop.sales-service-point-widget:1.1.0](https://github.com/spryker-shop/shop.sales-service-point-widget)<br>[spryker-shop/shop.service-point-widget:1.2.0](https://github.com/spryker-shop/shop.service-point-widget) |
| [Fixed order details incorrect prices display](https://api.release.spryker.com/release-group/5139) |100% |No | |
| [Foreign payment OMS has wrong names](https://api.release.spryker.com/release-group/5134) |50% |No | |
| [AsyncApi Tester incomplete validation for nested p...](https://api.release.spryker.com/release-group/5136) |100% |No |[spryker/testify-async-api:0.1.2](https://github.com/spryker/testify-async-api) |
| [Improved the `data:export` console command with op...](https://api.release.spryker.com/release-group/5135) |100% |No | |

There are also [releases](https://api.release.spryker.com/release-history?sort=released&direction=asc&project_only=1&released_from%5Bday%5D=27&released_from%5Bmonth%5D=11&released_from%5Byear%5D=2023), that did not include any modules, please check them out.



<details><summary><h2>List of packages</h2></summary>

**Packages upgraded:**

| Package | From | To | Changes | 
|---------|------|----|--------|
 | **spryker-shop/customer-page** | 2.47.0 | 2.49.0 | https://github.com/spryker-shop/customer-page/compare/2.47.0...2.49.0 | 
 | **spryker/customer** | 7.52.0 | 7.53.0 | https://github.com/spryker/customer/compare/7.52.0...7.53.0 | 
 | **spryker/security-gui** | 1.4.0 | 1.5.0 | https://github.com/spryker/security-gui/compare/1.4.0...1.5.0 | 
 | **spryker/user-password-reset** | 1.4.0 | 1.5.0 | https://github.com/spryker/user-password-reset/compare/1.4.0...1.5.0 | 
 | **spryker/state-machine** | 2.19.0 | 2.20.0 | https://github.com/spryker/state-machine/compare/2.19.0...2.20.0 | 
 | **spryker/cms-gui** | 5.13.0 | 5.14.0 | https://github.com/spryker/cms-gui/compare/5.13.0...5.14.0 | 
 | **spryker-shop/checkout-page** | 3.29.1 | 3.29.2 | https://github.com/spryker-shop/checkout-page/compare/3.29.1...3.29.2 | 
 | **spryker/catalog** | 5.9.0 | 5.10.0 | https://github.com/spryker/catalog/compare/5.9.0...5.10.0 | 
 | **spryker/product-configuration-wishlists-rest-api** | 1.1.3 | 1.1.4 | https://github.com/spryker/product-configuration-wishlists-rest-api/compare/1.1.3...1.1.4 | 
 | **spryker/product-configurations-rest-api** | 1.0.3 | 1.0.4 | https://github.com/spryker/product-configurations-rest-api/compare/1.0.3...1.0.4 | 
 | **spryker/transfer** | 3.34.0 | 3.35.0 | https://github.com/spryker/transfer/compare/3.34.0...3.35.0 | 
 | **spryker-shop/checkout-page** | 3.29.2 | 3.29.3 | https://github.com/spryker-shop/checkout-page/compare/3.29.2...3.29.3 | 
 | **spryker/sales** | 11.42.0 | 11.42.1 | https://github.com/spryker/sales/compare/11.42.0...11.42.1 | 
 | **spryker/sales-order-threshold-gui** | 1.9.0 | 1.9.1 | https://github.com/spryker/sales-order-threshold-gui/compare/1.9.0...1.9.1 | 
 | **spryker/shipment-gui** | 2.10.0 | 2.10.1 | https://github.com/spryker/shipment-gui/compare/2.10.0...2.10.1 | 
 | **spryker/sales-payment** | 1.3.2 | 1.4.0 | https://github.com/spryker/sales-payment/compare/1.3.2...1.4.0 | 
 | **spryker/message-broker** | 1.9.0 | 1.9.1 | https://github.com/spryker/message-broker/compare/1.9.0...1.9.1 | 
 | **spryker/tax-app** | 0.2.0 | 0.2.1 | https://github.com/spryker/tax-app/compare/0.2.0...0.2.1 | 
 | **spryker/data-export** | 0.1.3 | 0.1.4 | https://github.com/spryker/data-export/compare/0.1.3...0.1.4 | 
 | **spryker/price-product-schedule-gui** | 2.7.0 | 2.8.0 | https://github.com/spryker/price-product-schedule-gui/compare/2.7.0...2.8.0 | 
 | **spryker/product-list-gui** | 2.5.0 | 2.6.0 | https://github.com/spryker/product-list-gui/compare/2.5.0...2.6.0 | 
 | **spryker/util-csv** | 1.0.0 | 1.1.0 | https://github.com/spryker/util-csv/compare/1.0.0...1.1.0 | 

</details>


### Having trouble with Upgrader and going to contact Spryker?
- Check [Upgrader docs](https://docs.spryker.com/docs/scu/dev/spryker-code-upgrader.html)
- Please copy this report ID or content of this PR and send it to us. Report ID: 9525678a-a5bd-4cce-9eeb-7ffedb4bdd2f